### PR TITLE
feat (call-for-projects): Add Call for Projects page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,5 +18,6 @@
 		margin: 0;
 		width: 100%;
 		height: 100%;
+		line-height: 1.5;
 	}
 </style>

--- a/src/pages/callForProjects.astro
+++ b/src/pages/callForProjects.astro
@@ -1,0 +1,127 @@
+---
+
+---
+    <div class="container">
+        <header class="header">
+            <h1 class="main-title">Llamado a concurso de Proyectos de Grado y Proyectos de Investigación</h1>
+            <p>El Concurso de Proyectos de Grado y Proyectos de Investigación es un evento anual realizado por el Centro MEMI-FCyT-UMSS, cuyo objetivo es premiar y difundir el trabajo de estudiantes universitarios de las carreras del área de Informática que hayan terminado recientemente su proyecto de grado (entre julio del 2024 a junio del 2025) en el área de informática, cuyo contenido esté referido a algunas de las áreas disciplinarias definidas en la currícula de computación establecidas por la IEEE/ACM. Podrán participar solo estudiantes que se gradúen en universidades bolivianas.</p>
+        </header>
+
+        <section class="section">
+            <h2 class="section-title">Fechas Importantes</h2>
+            <ul class="list">
+                <li>Fecha límite para la recepción de trabajos: 13 de junio de 2025</li>
+                <li>Notificación: 27 de junio de 2025</li>
+                <li>Presentación en EILAI, 7 al 11 de julio</li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section-title">Proceso para participar</h2>
+            <p>Podrán participar personas que cumplan con todos los requisitos para obtener el grado de Licenciado o Ingeniero en el área de Informática dentro del período comprendido entre el 1 de julio de 2024 y el 1 de junio de 2025, en alguna Universidad de Bolivia. Los trabajos enviados deberán ser individuales (no grupales). Los postulantes deberán haber culminado completamente su plan de estudios, incluida la defensa de la tesis ante un tribunal examinador. Para participar en el concurso, cada postulante deberá presentar un resumen de su tesis donde aparezca únicamente él o ella como autor(a).</p>
+            <p>Cada postulación deberá contener el siguiente material en formato PDF:</p>
+            <ul class="list">
+                <li>Un resumen extendido, en español, de una longitud máxima de 12 páginas, incluyendo figuras y referencias bibliográficas, en el formato de presentación de la IEEE <a href="https://www.ieee.org/conferences/publishing/templates">template.</a></li>
+                <li>Un archivo PDF con la lista completa de los artículos y/o patentes y/o premios y distinciones académicas que se originaron del trabajo de tesis, y que se haya publicado en revistas y congresos, tanto internacionales como nacionales. En cada caso, se deberá incluir el listado completo de autores, e información del ranking del lugar de publicación (usando los índices de SJR, en el caso de estar indexado).</li>
+                <li>Una versión digitalizada de una certificación expedida por la institución que otorga el título, indicando que el/la postulante efectivamente cumplió con todos los requisitos para obtener el grado de Licenciatura o Ingeniería en el periodo estipulado en este concurso.</li>
+                <li>Una carta de presentación del postulante, conteniendo información del título del proyecto de grado o investigación, nombre, apellido(s) y correo electrónico del tutor, grado obtenido, y la universidad que lo expidió. En dicha carta, el postulante deberá indicar explícitamente que está entregando la documentación para participar en el concurso.</li>
+                <li>Una carta aval del representante de la universidad del postulante.</li>
+                <li>La entrega de los documentos arriba señalados deberá realizarse a través del formulario provisto por la EILAI <a href="https://forms.gle/17itNAhJHgTgvq1K7">Formulario de participación</a>, mediante el envío de un único archivo comprimido (.zip o .rar), que deberá denominarse .zip o .rar.</li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section-title">Premios</h2>
+            <p>El comité evaluador elegirá tres tesis finalistas para la premiación. Los premios consistirán en un certificado con valor curricular del Centro MEMI indicando el lugar obtenido en el concurso y se entregarán a los premiados en persona, luego de realizar una presentación de 30 minutos presencialmente en la sesión de premiación durante la Escuela de Invierno en Lenguajes y Aplicaciones Informáticas (EILAI 2025). De no realizar la presentación oral, no se tendrá derecho al premio correspondiente ni a la publicación digital en las memorias de la EILAI.</p>
+            <p>Un conjunto de trabajos seleccionados, incluyendo los tres premiados, serán invitados a ser publicados en una edición especial de CLEI Electronic Journal. Los autores invitados deberán presentar una versión mejorada en inglés que se diferencia por lo menos un 30% de cada una de las publicaciones ya realizadas, la que tendrá un nuevo proceso de evaluación por los revisores asignados por el CLEI Electronic Journal.</p>
+        </section>
+
+        <section class="section">
+            <h2 class="section-title">Cómite de Programa</h2>
+            <pre>
+                <code>* Vladimir Costas - UMSS </code>
+            </pre>
+        </section>
+    </div>
+
+<style>
+    .container {
+        max-width: 1000px;
+        margin: 40px auto;
+        margin-bottom: .5em;
+        font-family: system-ui,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',sans-serif;
+        padding: 20px;
+        background-color: #fff;
+        border-radius: 8px;
+    }
+    
+    .header {
+        text-align: left;
+        margin-bottom: 40px;
+    }
+
+    .main-title {
+        font-size: 3.8rem;
+        font-weight: 610;
+        color: #3a414e;
+        margin-bottom: 20px;
+        line-height: 1.2;
+    }
+
+    .section {
+        margin-top: 30px;
+    }
+
+    .section-title {
+        font-size: 2.4em;
+        font-weight: 600;
+        color: #3a414e;
+        margin-bottom: 15px;
+        padding-bottom: 5px;
+    }
+
+    .list {
+        list-style: none;
+        font-size: 1rem;
+        padding: 0;
+        margin: 0;
+        color: #50596c;
+    }
+
+    .list li {
+        margin-bottom: 10px;
+        padding-left: 1.5em;
+        position: relative;
+    }
+
+    .list li::before {
+        content: "•";
+        color: #3a414e;
+        font-weight: bold;
+        position: absolute;
+        left: 0;
+        top: 0;
+    }
+
+    p {
+        margin-bottom: 1em;
+        font-size: 1rem;
+        color: #50596c;
+    }
+    a {
+        color: #5fa1f2;
+        text-decoration: none;
+    }
+    a:hover,
+    a:focus {
+        text-decoration: underline;
+    }
+
+
+    code {
+        padding: 1rem !important;
+        display: block;
+        background-color: #f3f4f7;
+        color:#50596c;
+    }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,12 @@
 ---
 import Welcome from '../components/Welcome.astro';
 import Layout from '../layouts/Layout.astro';
+import CallForProjects from './callForProjects.astro';
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
 // Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
 ---
 
 <Layout>
-	<Welcome />
+	<CallForProjects />
 </Layout>


### PR DESCRIPTION
### Descripción
Se agrega la página "Llamado a Concurso de Proyectos de Graduación" (`callForProjects.astro`) con contenido estático y estilos centralizados. La página incluye:

- Información sobre la Escuela de Invierno en Lenguajes y Aplicaciones de Informática (EILAI).
- Secciones de registro e inscripciones, logística, programa y contacto.
- Estilos CSS centralizados y variables para mantener consistencia de tipografía y colores.

### Cambios principales
- Creación del archivo `src/pages/callForProjects.astro`.
